### PR TITLE
fix: implemented rate limiter for model to reduce token throttling

### DIFF
--- a/JSInjections/clickNode.js
+++ b/JSInjections/clickNode.js
@@ -3,7 +3,7 @@ function clickNode(testid) {
   const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
 
   setTimeout(() => {
-    const node = iframeDoc.querySelector(`g[data-testid="group:AWS::${testid}"]`);
+    const node = iframeDoc.querySelector(`g[data-testid="${testid}"]`);
     if (node) {
       const nodeBounds = node.getBoundingClientRect();
       const nodeHoverX = nodeBounds.left + nodeBounds.width / 2;

--- a/Tests/Test8.txt
+++ b/Tests/Test8.txt
@@ -1,7 +1,7 @@
 Determine if the given test passed or failed with the following steps:
 
 1. In the left panel, under Application Signals, click 'Service Map'.
-2. Access the node, PASS in "SQS" (MAKE SURE IT IS ALL CAPITALS) as the PARAMETER.
+2. Access the node in the Service Map, PASS in "group:AWS::SQS" as the PARAMETER.
 3. Wait a few seconds.
 4. Click on the bottom link in the 'Top three paths by error rate' dropdown in the right panel.
 5. Click the 'Dependencies' button.


### PR DESCRIPTION
### Issue
Encountered `ThrottlingException` errors from Bedrock Claude during longer test executions:
`An error occurred (ThrottlingException) when calling the Converse operation: Too many tokens, please wait before trying again.`
This was causing the agent to fail and exit before test completion.

I was recieving a `ThrottlingException` due to using too many tokens during test execution.

### Description of Changes
Implemented an `InMemoryRateLimiter` for the Claude model to prevent token throttling errors by pacing requests.

- Configured the limiter to allow 1 request every 10 seconds
- Integrated the limiter by passing it into the `ChatBedrockConverse` model trhough the `rate_limiter` parameter
