### PR TITLE
fix: changed Session() logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ We utilize custom Actions to authenticate and federate an AWS link automatically
 To try running this on your local machine, ensure that you have at least `ReadOnly` access to the apm-demo1 acccount and run the following commands after cloning the repository:
 1. Run `mwinit` to generate new credentials  
 
-2. Run `ada credentials update --account=<apm-demo1_account_id> --provider=isengard --once --role=<Role>`
-3. Run `ada credentials update --account=<account for Bedrock use> --provider=isengard --once --role=<Role> --profile=bedrock-access`
+2. Run `ada credentials update --account=<apm-demo1_account_id> --provider=isengard --once --role=<Role> --profile=auth-access`
+3. Run `ada credentials update --account=<account for Bedrock, S3, CloudWatch> --provider=isengard --once --role=<Role>`
 4. Run `pip install browser-use==0.2.5` to install browser-use (we want to remain on version `0.2.5`, but this can be changed in the future)
 5. Run `pip install "browser-use[memory]"` to install memory functionality
 
@@ -25,7 +25,7 @@ AWS_ACCOUNT_ID=<ACCOUNT_ID>
 DEBUG_MODE=<True/False>
 ```
 
-**Note:** The `AWS_ACCOUNT_ID` and `AWS_REGION` should be the ID and region for the account used in Step 3 from "Quick Start" for Bedrock access.
+**Note:** The `AWS_ACCOUNT_ID` and `AWS_REGION` should be the ID and region for the account used in Step 3 from "Quick Start".
 
 ## Debugging
 

--- a/libs/main.py
+++ b/libs/main.py
@@ -170,7 +170,7 @@ async def test_result(params: TestResult):
     if not params.x:
         test_failed = True
 
-    session = Session(profile_name='bedrock-access')
+    session = Session()
     cloudwatch = session.client('cloudwatch', region_name=region)
 
     metric_name = "Failure"
@@ -274,7 +274,7 @@ async def scrolling(params: ScrollingParameters, browser: BrowserContext):
     return ActionResult(extracted_content=logs, include_in_memory=False)
 
 def get_llm(modelID):
-    session = Session(profile_name='bedrock-access')
+    session = Session()
 
     config = Config(
         read_timeout=60*5,
@@ -301,7 +301,7 @@ def get_llm(modelID):
     )
 
 def authentication_open():
-    session = botocore.session.get_session()
+    session = Session(profile_name='auth-access')
     creds = session.get_credentials().get_frozen_credentials()
 
     session_dict = {
@@ -378,7 +378,7 @@ async def main():
     history = await agent.run(max_steps=70)
 
     bucket_name = "aitestscreenshots"
-    session = Session(profile_name='bedrock-access')
+    session = Session()
     s3_client = session.client('s3', region_name=region)
 
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")


### PR DESCRIPTION
## Summary

This PR updates Session logic to use default credentials for Bedrock, S3, and CloudWatch access, and "auth-access" for demo account authentication.

## Directory Structure
This project is structured as follows:
- **/libs/JSInjections**: JavaScript snippets injected into the browser to support unsupported UI interactions  (e.g., graph clicks, node expansion)
- **/libs/Tests**: Contains `.txt` files with task prompts for each individual test.
- **/libs/main.py**: Includes test execution logic.

## Description Of Changes
This PR introduces the following:
- **Session logic**: Switches default credentials to be used for Bedrock, S3, and CloudWatch, and "auth-access" for authentication 