### PR TITLE
fix: refactored publish metric and s3 upload logic

### DIFF
--- a/libs/main.py
+++ b/libs/main.py
@@ -171,34 +171,7 @@ async def test_result(params: TestResult):
     global test_failed
     if not params.x:
         test_failed = True
-
-    session = Session()
-    cloudwatch = session.client('cloudwatch', region_name=region)
-
-    metric_name = "Failure"
-
-    cloudwatch.put_metric_data(
-        Namespace=cloudwatch_namespace,
-        MetricData=[
-            {
-                "MetricName": metric_name,
-                "Dimensions": [
-                    {
-                        "Name": "Language",
-                        "Value": "Python"
-                    },
-                    {
-                        "Name": "Source",
-                        "Value": "Local"
-                    }
-                ],
-                "Value": 0.0 if params.x else 1.0,
-            }
-        ]
-    )
-    print(f"Published metric: {metric_name} in namespace {cloudwatch_namespace} as {'0.0' if params.x else '1.0'}")
     return ActionResult(extracted_content="The task is COMPLETE - you can EXIT now. DO NOT conduct anymore steps!!!", is_done=True)
-
 
 @controller.action(
     'Access the node in the Service Map',
@@ -327,6 +300,49 @@ def authentication_open():
 
     return login_url
 
+def publish_metric(result, session):
+    cloudwatch = session.client('cloudwatch', region_name=region)
+
+    metric_name = "Failure"
+
+    cloudwatch.put_metric_data(
+        Namespace=cloudwatch_namespace,
+        MetricData=[
+            {
+                "MetricName": metric_name,
+                "Dimensions": [
+                    {
+                        "Name": "Language",
+                        "Value": "Python"
+                    },
+                    {
+                        "Name": "Source",
+                        "Value": "Local"
+                    }
+                ],
+                "Value": 0.0 if not result else 1.0,
+            }
+        ]
+    )
+    print(f"Published metric: {metric_name} in namespace {cloudwatch_namespace} as {'0.0' if not result else '1.0'}")
+
+def upload_s3(screenshots, test_id, session):
+    s3_client = session.client('s3', region_name=region)
+
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    s3_prefix = f"screenshots/test-{test_id}/{timestamp}/"
+
+    for i, screenshot in enumerate(screenshots):
+        screenshot_data = base64.b64decode(screenshot)
+        s3_key = f"{s3_prefix}screenshot_{i}.png"
+
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key=s3_key,
+            Body=screenshot_data,
+            ContentType="image/png"
+        )
+
 async def main():
     startTime = time.time()
     # Get test prompt file
@@ -379,22 +395,12 @@ async def main():
     history = await agent.run(max_steps=70)
 
     session = Session()
-    s3_client = session.client('s3', region_name=region)
 
-    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    s3_prefix = f"screenshots/test-{test_id}/{timestamp}/"
+    publish_metric(test_failed, session)
 
     if debug_mode or test_failed:
-        for i, screenshot in enumerate(history.screenshots()):
-            screenshot_data = base64.b64decode(screenshot)
-            s3_key = f"{s3_prefix}screenshot_{i}.png"
+        upload_s3(history.screenshots(), test_id, session)
 
-            s3_client.put_object(
-                Bucket=bucket_name,
-                Key=s3_key,
-                Body=screenshot_data,
-                ContentType="image/png"
-            )
     await browser_session.close()
     endTime = time.time()
     print(f"Time taken: {endTime - startTime} seconds")


### PR DESCRIPTION
## Summary

This PR refactors the logic to publish a metric to the CloudWatch console and upload screenshots to S3. The Agent sometimes calls the `test_result` function multiple times in one test run, which publishes a metric each time. By moving this logic to `main()`, each test, only one metric will be published to CloudWatch.

The logic to upload screenshots to S3 is moved into a function for easier readability. If `debug_mode` is `True` or the test failed (`test_failed`), we upload the screenshots for the test to S3.

## Description Of Changes
This PR introduces the following:
- **Publish Metric Refactor:** Logic to publish a metric is moved from `test_result` to after the test is completed (`main()`)
- **S3 Upload Refactor**: Logic to upload screenshots to S3 is moved into a function